### PR TITLE
Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   tests:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -207,3 +207,5 @@ This tool requires a git repository to function properly as it uses `git ls-file
 Version 3, 19 November 2007
 © 2024 Geoff Seemueller
 
+
+


### PR DESCRIPTION
Added `contents: read` and `pull-requests: read` permissions to the `publish` and `tests` workflows. This ensures the workflows operate under the principle of least privilege, enhancing security.
