### PR TITLE
Add `.toak-ignore` to .gitignore and implement updateGitignore method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /dist/
 prompt.md
 todo
+.toak-ignore


### PR DESCRIPTION
Enhanced MarkdownGenerator to update .gitignore programmatically when required, introduced tests for updateGitignore functionality, and ensured `.toak-ignore` is added.